### PR TITLE
Support to only include whitelisted fields

### DIFF
--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
@@ -24,6 +24,8 @@ import com.google.auto.value.AutoValue;
 
 import java.io.Serializable;
 import java.sql.Connection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 @AutoValue
@@ -39,6 +41,8 @@ public abstract class JdbcExportArgs implements Serializable {
 
   public abstract Boolean useAvroLogicalTypes();
 
+  public abstract List<String> fields();
+
   @AutoValue.Builder
   abstract static class Builder {
 
@@ -52,26 +56,34 @@ public abstract class JdbcExportArgs implements Serializable {
 
     abstract Builder setUseAvroLogicalTypes(Boolean useAvroLogicalTypes);
 
+    abstract Builder setFields(List<String> fields);
+
     abstract JdbcExportArgs build();
   }
 
   public static JdbcExportArgs create(JdbcAvroArgs jdbcAvroArgs,
                                       QueryBuilderArgs queryBuilderArgs) {
-    return create(jdbcAvroArgs, queryBuilderArgs,
-                  "dbeam_generated", Optional.empty(), false);
+    return create(jdbcAvroArgs,
+            queryBuilderArgs,
+            "dbeam_generated",
+            Optional.empty(),
+            false,
+            Collections.emptyList());
   }
 
   public static JdbcExportArgs create(JdbcAvroArgs jdbcAvroArgs,
                                       QueryBuilderArgs queryBuilderArgs,
                                       String avroSchemaNamespace,
                                       Optional<String> avroDoc,
-                                      Boolean useAvroLogicalTypes) {
+                                      Boolean useAvroLogicalTypes,
+                                      List<String> fields) {
     return new AutoValue_JdbcExportArgs.Builder()
         .setJdbcAvroOptions(jdbcAvroArgs)
         .setQueryBuilderArgs(queryBuilderArgs)
         .setAvroSchemaNamespace(avroSchemaNamespace)
         .setAvroDoc(avroDoc)
         .setUseAvroLogicalTypes(useAvroLogicalTypes)
+        .setFields(fields == null ? Collections.emptyList() : fields)
         .build();
   }
 

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilderArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilderArgs.java
@@ -26,8 +26,10 @@ import com.google.common.collect.Lists;
 
 import java.io.Serializable;
 import java.sql.Connection;
+import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Days;
 import org.joda.time.LocalDate;
@@ -49,6 +51,8 @@ public abstract class QueryBuilderArgs implements Serializable {
 
   public abstract ReadablePeriod partitionPeriod();
 
+  public abstract Optional<List<String>> fields();
+
   public abstract Builder builder();
 
   @AutoValue.Builder
@@ -69,6 +73,8 @@ public abstract class QueryBuilderArgs implements Serializable {
     public abstract Builder setPartition(Optional<DateTime> partition);
 
     public abstract Builder setPartitionPeriod(ReadablePeriod partitionPeriod);
+
+    public abstract Builder setFields(Optional<List<String>> fields);
 
     public abstract QueryBuilderArgs build();
   }
@@ -99,8 +105,14 @@ public abstract class QueryBuilderArgs implements Serializable {
                                    partitionColumn, datePartition, partitionColumn, nextPartition);
             })
     ).orElse("");
+    String fieldsList;
+    if (!fields().isPresent()) {
+      fieldsList = "*";
+    } else {
+      fieldsList = StringUtils.join(fields().get(), ',');
+    }
     return Lists.newArrayList(
-        String.format("SELECT * FROM %s%s%s", this.tableName(), where, limit));
+        String.format("SELECT %s FROM %s%s%s", fieldsList, this.tableName(), where, limit));
   }
 
 }

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/BeamJdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/BeamJdbcAvroSchema.java
@@ -53,7 +53,7 @@ public class BeamJdbcAvroSchema {
       dbName = connection.getCatalog();
       generatedSchema = JdbcAvroSchema.createSchemaByReadingOneRow(
           connection, args.queryBuilderArgs().tableName(),
-          args.avroSchemaNamespace(), avroDoc, args.useAvroLogicalTypes());
+          args.avroSchemaNamespace(), avroDoc, args.useAvroLogicalTypes(), args.fields());
     }
     final long elapsedTimeSchema = System.currentTimeMillis() - startTimeMillis;
     LOGGER.info("Elapsed time to schema {} seconds", elapsedTimeSchema / 1000.0);

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
@@ -52,8 +52,10 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,13 +65,19 @@ public class JdbcAvroSchema {
 
   public static Schema createSchemaByReadingOneRow(
       Connection connection, String tableName, String avroSchemaNamespace,
-      String avroDoc, boolean useLogicalTypes)
+      String avroDoc, boolean useLogicalTypes, List<String> fields)
       throws SQLException {
     LOGGER.debug("Creating Avro schema based on the first read row from the database");
     try (Statement statement = connection.createStatement()) {
+      String fieldsList;
+      if (fields.isEmpty()) {
+        fieldsList = "*";
+      } else {
+        fieldsList = StringUtils.join(fields, ',');
+      }
       final ResultSet
           resultSet =
-          statement.executeQuery(String.format("SELECT * FROM %s LIMIT 1", tableName));
+          statement.executeQuery(String.format("SELECT %s FROM %s LIMIT 1", fieldsList, tableName));
 
       Schema schema = JdbcAvroSchema.createAvroSchema(
           resultSet, avroSchemaNamespace, connection.getMetaData().getURL(), avroDoc,

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
@@ -20,6 +20,7 @@
 
 package com.spotify.dbeam.options;
 
+import java.util.List;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 
@@ -90,4 +91,10 @@ public interface JdbcExportPipelineOptions extends DBeamPipelineOptions {
   String getAvroCodec();
 
   void setAvroCodec(String value);
+
+  @Description(
+          "List of whitelisted fields. If not provided, all fields are exported.")
+  List<String> getFields();
+
+  void setFields(List<String> value);
 }

--- a/dbeam-core/src/test/scala/com/spotify/dbeam/args/JdbcExportArgsTest.scala
+++ b/dbeam-core/src/test/scala/com/spotify/dbeam/args/JdbcExportArgsTest.scala
@@ -297,4 +297,16 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
         "--table=some_table --password=secret --avroCodec=lzma")
     }
   }
+  it should "configure fields to include" in {
+    val options = optionsFromArgs("--connectionUrl=jdbc:postgresql://some_db --table=some_table " +
+      "--password=secret --fields=field1,field2")
+
+    options.fields() should be (List("field1", "field2").asJava)
+  }
+  it should "fail on invalid field name" in {
+    a[IllegalArgumentException] should be thrownBy {
+      optionsFromArgs("--connectionUrl=jdbc:postgresql://some_db " +
+        "--table=some_table --password=secret --fields=field1,field:2,field3")
+    }
+  }
 }

--- a/dbeam-core/src/test/scala/com/spotify/dbeam/avro/JdbcAvroRecordTest.scala
+++ b/dbeam-core/src/test/scala/com/spotify/dbeam/avro/JdbcAvroRecordTest.scala
@@ -46,7 +46,7 @@ class JdbcAvroRecordTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     val actual: Schema = JdbcAvroSchema.createSchemaByReadingOneRow(
       db.source.createConnection(),
       "coffees", "dbeam_generated",
-      "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test", false)
+      "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test", false, List[String]().asJava)
 
     actual shouldNot be (null)
     actual.getNamespace should be ("dbeam_generated")
@@ -78,13 +78,40 @@ class JdbcAvroRecordTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     actual.getDoc should be ("Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test")
   }
 
+  it should "create schema with only two fields" in {
+    val fieldCount = 2
+    val actual: Schema = JdbcAvroSchema.createSchemaByReadingOneRow(
+      db.source.createConnection(),
+      "coffees", "dbeam_generated",
+      "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test", false,
+      List[String]("COF_NAME", "UID").asJava)
+
+    actual shouldNot be (null)
+    actual.getNamespace should be ("dbeam_generated")
+    actual.getProp("tableName") should be ("COFFEES")
+    actual.getProp("connectionUrl") should be ("jdbc:h2:mem:test")
+    actual.getFields.size() should be (fieldCount)
+    actual.getFields.asScala.map(_.name()) should
+      be (List("COF_NAME", "UID"))
+    actual.getFields.asScala.map(_.schema().getType) should
+      be (List.fill(fieldCount)(Schema.Type.UNION))
+    actual.getFields.asScala.map(_.schema().getTypes.get(0).getType) should
+      be (List.fill(fieldCount)(Schema.Type.NULL))
+    actual.getFields.asScala.map(_.schema().getTypes.size()) should be (List.fill(fieldCount)(2))
+    actual.getField("COF_NAME").schema().getTypes.get(1).getType should be (Schema.Type.STRING)
+    actual.getField("UID").schema().getTypes.get(1).getType should be (Schema.Type.BYTES)
+    actual.toString shouldNot be (null)
+    actual.getDoc should be ("Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test")
+  }
+
   it should "create schema with logical types" in {
     val fieldCount = 12
     val actual: Schema = JdbcAvroSchema.createSchemaByReadingOneRow(
       db.source.createConnection(),
       "coffees", "dbeam_generated",
       "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test",
-      true)
+      true,
+      List[String]().asJava)
 
     actual shouldNot be (null)
     actual.getNamespace should be ("dbeam_generated")
@@ -119,7 +146,7 @@ class JdbcAvroRecordTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   it should "create schema under specified namespace" in {
     val actual: Schema = JdbcAvroSchema.createSchemaByReadingOneRow(
-      db.source.createConnection(), "coffees", "ns", "doc", false)
+      db.source.createConnection(), "coffees", "ns", "doc", false, List[String]().asJava)
 
     actual shouldNot be (null)
     actual.getNamespace should be ("ns")
@@ -127,7 +154,7 @@ class JdbcAvroRecordTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   it should "create schema with specified doc string" in {
     val actual: Schema = JdbcAvroSchema.createSchemaByReadingOneRow(
-      db.source.createConnection(), "coffees", "ns", "doc", false)
+      db.source.createConnection(), "coffees", "ns", "doc", false, List[String]().asJava)
 
     actual shouldNot be (null)
     actual.getDoc should be ("doc")


### PR DESCRIPTION
To reduce data moved and unintentional schema changes we only want to export
explicit field. The option --fields is added and take a comma separated list
of fields to include.