### PR TITLE
Use provided table name if avaliable

### DIFF
--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
@@ -54,6 +54,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
@@ -81,7 +82,7 @@ public class JdbcAvroSchema {
           statement.executeQuery(String.format("SELECT %s FROM %s LIMIT 1", fieldsList, tableName));
 
       Schema schema = JdbcAvroSchema.createAvroSchema(
-          resultSet, avroSchemaNamespace, connection.getMetaData().getURL(), avroDoc,
+          resultSet, avroSchemaNamespace, tableName, connection.getMetaData().getURL(), avroDoc,
           useLogicalTypes);
       LOGGER.info("Schema created successfully. Generated schema: {}", schema.toString());
       return schema;
@@ -89,13 +90,14 @@ public class JdbcAvroSchema {
   }
 
   public static Schema createAvroSchema(
-      ResultSet resultSet, String avroSchemaNamespace, String connectionUrl,
-      String avroDoc, boolean useLogicalTypes)
+      ResultSet resultSet, String avroSchemaNamespace, String tableNameProvided,
+      String connectionUrl, String avroDoc, boolean useLogicalTypes)
       throws SQLException {
     ResultSetMetaData meta = resultSet.getMetaData();
     String tableName = "no_table_name";
-
-    if (meta.getColumnCount() > 0) {
+    if (Objects.nonNull(tableNameProvided) && !tableNameProvided.isEmpty()) {
+      tableName = tableNameProvided;
+    } else if (meta.getColumnCount() > 0) {
       tableName = normalizeForAvro(meta.getTableName(1));
     }
     SchemaBuilder.FieldAssembler<Schema> builder = SchemaBuilder.record(tableName)

--- a/dbeam-core/src/test/scala/com/spotify/dbeam/avro/JdbcAvroRecordTest.scala
+++ b/dbeam-core/src/test/scala/com/spotify/dbeam/avro/JdbcAvroRecordTest.scala
@@ -45,7 +45,7 @@ class JdbcAvroRecordTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     val fieldCount = 12
     val actual: Schema = JdbcAvroSchema.createSchemaByReadingOneRow(
       db.source.createConnection(),
-      "coffees", "dbeam_generated",
+      "COFFEES", "dbeam_generated",
       "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test", false, Map[String, Optional[String]]().asJava)
 
     actual shouldNot be (null)
@@ -82,7 +82,7 @@ class JdbcAvroRecordTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     val fieldCount = 2
     val actual: Schema = JdbcAvroSchema.createSchemaByReadingOneRow(
       db.source.createConnection(),
-      "coffees", "dbeam_generated",
+      "COFFEES", "dbeam_generated",
       "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test", false,
       Map[String, Optional[String]](("COF_NAME", Optional.empty()), ("UID", Optional.empty())).asJava)
 
@@ -108,7 +108,7 @@ class JdbcAvroRecordTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     val fieldCount = 12
     val actual: Schema = JdbcAvroSchema.createSchemaByReadingOneRow(
       db.source.createConnection(),
-      "coffees", "dbeam_generated",
+      "COFFEES", "dbeam_generated",
       "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test",
       true,
       Map[String, Optional[String]]().asJava)
@@ -170,7 +170,7 @@ class JdbcAvroRecordTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   it should "convert jdbc result set to avro generic record" in {
     val rs = db.source.createConnection().createStatement().executeQuery(s"SELECT * FROM coffees")
-    val schema = JdbcAvroSchema.createAvroSchema(rs, "dbeam_generated","connection", "doc", false)
+    val schema = JdbcAvroSchema.createAvroSchema(rs, "dbeam_generated", "table_name", "connection", "doc", false)
     rs.next()
 
     val mappings = JdbcAvroRecord.computeAllMappings(rs)


### PR DESCRIPTION
When using function transformations table name is not avaliable from metadata.
Instead use provided table name at first hand.